### PR TITLE
mako: use BFQ io scheduler

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -269,6 +269,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 	ro.qc.sensors.wl_dis=true \
 	ro.qualcomm.sensors.smd=true
 
+# IO Scheduler
+PRODUCT_PROPERTY_OVERRIDES += \
+	sys.io.scheduler=bfq
+
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
 	persist.sys.usb.config=mtp
 


### PR DESCRIPTION
To take advantage of recent optimizations using BFQ

Change-Id: I5430961d87aeee6fa1031e81d5588eb71c06846d
